### PR TITLE
Allow output to stdout

### DIFF
--- a/bin/runtype.js
+++ b/bin/runtype.js
@@ -20,7 +20,7 @@ const {
   output,
 } = program
 
-if (!globPattern || !output) {
+if (!globPattern) {
   program.outputHelp()
   process.exit(1)
 }
@@ -29,5 +29,12 @@ const files = glob.sync(globPattern)
 const data = parse(files)
 const javascript = render(data)
 
-mkdirp.sync(path.dirname(output))
-fs.writeFileSync(output, javascript)
+if (output) {
+  mkdirp.sync(path.dirname(output))
+}
+
+const outStream = output ?
+  fs.createWriteStream(output) :
+  process.stdout
+
+outStream.write(javascript)


### PR DESCRIPTION
If a user omits the output variable, spit to stdout.

I figure it might be useful in some cases to pipe the output through other operations.

Thoughts?